### PR TITLE
chore: Configure packages for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,31 @@
   "version": "0.1.0",
   "description": "Unified Observability & Orchestration SDK for Multi-Model AI Applications",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js"
+    },
+    "./tracing": {
+      "types": "./dist/tracing/index.d.ts",
+      "import": "./dist/tracing/index.js"
+    },
+    "./routing": {
+      "types": "./dist/routing/index.d.ts",
+      "import": "./dist/routing/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "workspaces": [
     "packages/*"
   ],
@@ -20,7 +44,8 @@
     "lint:fix": "eslint src --ext .ts --fix",
     "typecheck": "tsc --noEmit",
     "dashboard": "npm run dev -w @llm-orchestra/dashboard",
-    "dashboard:cli": "npm run cli -w @llm-orchestra/dashboard"
+    "dashboard:cli": "npm run cli -w @llm-orchestra/dashboard",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "llm",
@@ -33,7 +58,9 @@
     "gpt",
     "gemini",
     "tracing",
-    "multi-model"
+    "multi-model",
+    "failover",
+    "cost-tracking"
   ],
   "author": "TROZLAN <info@trozlan.io>",
   "license": "MIT",
@@ -47,6 +74,9 @@
   "homepage": "https://github.com/MegaPhoenix92/llm-orchestra#readme",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,33 +3,73 @@
   "version": "0.1.0",
   "description": "Local observability dashboard for LLM Orchestra",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/app.d.ts",
+      "import": "./dist/server/app.js"
+    },
+    "./cli": {
+      "types": "./dist/cli/index.d.ts",
+      "import": "./dist/cli/index.js"
+    }
+  },
   "bin": {
     "orchestra-dashboard": "./bin/orchestra-dashboard.js"
   },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/server/app.ts",
     "cli": "tsx src/cli/index.ts",
     "start": "node dist/server/app.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "llm-orchestra",
     "dashboard",
     "observability",
-    "tracing"
+    "tracing",
+    "llm",
+    "ai",
+    "monitoring",
+    "cli"
   ],
   "author": "TROZLAN <info@trozlan.io>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MegaPhoenix92/llm-orchestra.git",
+    "directory": "packages/dashboard"
+  },
+  "bugs": {
+    "url": "https://github.com/MegaPhoenix92/llm-orchestra/issues"
+  },
+  "homepage": "https://github.com/MegaPhoenix92/llm-orchestra/tree/main/packages/dashboard#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
-    "hono": "^4.0.0",
     "@hono/node-server": "^1.8.0",
-    "commander": "^12.0.0",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.3",
+    "commander": "^12.0.0",
+    "hono": "^4.0.0",
     "open": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add `exports` field for proper ESM subpath exports in both packages
- Add `files` field to specify published contents
- Add `publishConfig` for public npm access
- Add `type: "module"` for ESM compatibility
- Add repository/bugs/homepage URLs
- Add `prepublishOnly` script to ensure build before publish

## Packages Updated
- `llm-orchestra` (main package): 107 files, 52.2 KB
- `@llm-orchestra/dashboard` (dashboard package): 87 files, 33.2 KB

## Test plan
- [x] All 395 tests pass
- [x] Build succeeds for both packages
- [x] npm pack --dry-run shows correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)