### PR TITLE
docs: add streaming usage example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,9 @@ Simple completion request with cost tracking and stats.
 ### Tool Use (`tool-use.ts`)
 Using function calling/tools with LLM Orchestra.
 
+### Streaming (`streaming.ts`)
+Stream tokens in real time and capture final metadata (tokens, cost, trace ID).
+
 ### Dashboard Integration (`with-dashboard.ts`)
 Real-time monitoring dashboard attached to Orchestra instance.
 
@@ -54,6 +57,9 @@ npx tsx examples/workflow.ts
 
 # With dashboard (opens browser)
 npx tsx examples/with-dashboard.ts
+
+# Streaming
+npx tsx examples/streaming.ts
 
 # Tracing (requires OTEL collector)
 OTEL_EXPORTER_ENDPOINT=http://localhost:4318/v1/traces npx tsx examples/tracing-export.ts

--- a/examples/streaming.ts
+++ b/examples/streaming.ts
@@ -1,0 +1,58 @@
+/**
+ * Streaming completion example
+ */
+
+import { Orchestra } from 'llm-orchestra';
+
+const openaiKey = process.env.OPENAI_API_KEY;
+const anthropicKey = process.env.ANTHROPIC_API_KEY;
+
+if (!openaiKey && !anthropicKey) {
+  throw new Error('Set OPENAI_API_KEY or ANTHROPIC_API_KEY to run this example.');
+}
+
+const model = openaiKey ? 'gpt-4o-mini' : 'claude-3-haiku';
+
+const orchestra = new Orchestra({
+  providers: {
+    ...(openaiKey ? { openai: { apiKey: openaiKey } } : {}),
+    ...(anthropicKey ? { anthropic: { apiKey: anthropicKey } } : {}),
+  },
+  observability: {
+    tracing: { enabled: true },
+    costTracking: { enabled: true },
+  },
+});
+
+async function main() {
+  console.log(`Streaming from ${model}...\n`);
+
+  const stream = orchestra.stream({
+    model,
+    messages: [
+      { role: 'system', content: 'You are a concise assistant.' },
+      { role: 'user', content: 'Write a 3-line haiku about the ocean.' },
+    ],
+  });
+
+  for await (const chunk of stream) {
+    if (chunk.content) {
+      process.stdout.write(chunk.content);
+    }
+
+    if (chunk.finishReason && chunk.meta) {
+      console.log('\n\n---');
+      console.log('Finish reason:', chunk.finishReason);
+      console.log('Tokens:', chunk.meta.tokens);
+      console.log('Cost:', chunk.meta.cost);
+      console.log('Trace ID:', chunk.meta.traceId);
+    }
+  }
+
+  await orchestra.shutdown();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `streaming.ts` example demonstrating real-time token streaming
- Update examples README with streaming documentation

## Features
- Auto-detects OpenAI or Anthropic API key
- Uses `orchestra.stream()` for real-time output
- Displays final metadata (tokens, cost, trace ID) on completion

## Test plan
- [x] All 402 tests pass
- [x] Example runs with `npx tsx examples/streaming.ts`

🤖 Co-authored by Codex and Claude