### PR TITLE
docs: add TypeDoc API documentation with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "docs"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build API docs
+        run: npm run docs:api
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/api
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ agentcoord.md
 # Test coverage
 coverage/
 
+# Generated docs
+docs/api/
+
 # Cache
 .cache/
 .turbo/

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "typecheck": "tsc --noEmit",
+    "docs:api": "typedoc --options typedoc.json",
     "dashboard": "npm run dev -w llm-orchestra-dashboard",
     "dashboard:cli": "npm run cli -w llm-orchestra-dashboard",
     "prepublishOnly": "npm run build"
@@ -86,6 +87,7 @@
     "@vitest/ui": "^1.6.1",
     "eslint": "^8.0.0",
     "tsx": "^4.0.0",
+    "typedoc": "^0.25.13",
     "typescript": "^5.0.0",
     "vitest": "^1.6.1"
   },

--- a/src/orchestra.ts
+++ b/src/orchestra.ts
@@ -392,7 +392,7 @@ export class Orchestra {
         avgLatencyMs: 0,
       };
     }
-    const providerStats = this.stats.byProvider[provider];
+    const providerStats = this.stats.byProvider[provider]!;
     const prevAvg = providerStats.avgLatencyMs;
     const prevCount = providerStats.requests;
     providerStats.requests++;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs/api",
+  "tsconfig": "tsconfig.json",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeInternal": true,
+  "includeVersion": true,
+  "hideGenerator": true
+}


### PR DESCRIPTION
## Summary
Set up automatic API documentation generation and deployment to GitHub Pages.

## Changes
- `typedoc.json` - TypeDoc configuration
- `package.json` - Add `docs:api` script and typedoc dependency
- `.github/workflows/docs.yml` - GitHub Actions workflow for auto-deployment
- `.gitignore` - Ignore generated docs directory
- `src/orchestra.ts` - Fix TypeScript strictness for TypeDoc compatibility

## Features
- Auto-generates docs on push to main
- Deploys to GitHub Pages
- Excludes private/protected/internal members
- Includes version in docs

## Test plan
- [x] All 415 tests pass
- [x] `npm run docs:api` generates docs successfully
- [x] Docs output to `docs/api/`

## After merge
Enable GitHub Pages in repo settings → Source: GitHub Actions

🤖 Co-authored by Codex and Claude