### PR TITLE
fix(deps): resolve critical fast-xml-parser vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,99 +179,50 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.974.0.tgz",
-      "integrity": "sha512-od/XNew1bMAC8yG80FVRGwmqCac/noY3wP1o4s+zOsYGTo3ev9fY2obFjkAM5TS7tiF5Llmp27QM2e/DKdqvAw==",
+      "version": "3.997.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.997.0.tgz",
+      "integrity": "sha512-rQEtjufwP/2ju8It4QYy8Ijj9KE9jilCFfQ0zztlW07CVweSY5pxtljyr5d3gPsdUOcCPo9J5cexYRjnL//NzA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/credential-provider-node": "^3.972.1",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/signature-v4-multi-region": "3.972.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.974.0.tgz",
-      "integrity": "sha512-ci+GiM0c4ULo4D79UMcY06LcOLcfvUfiyt8PzNY0vbt5O8BfCPYf4QomwVgkNcLLCYmroO4ge2Yy1EsLUlcD6g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/credential-provider-node": "^3.972.12",
+        "@aws-sdk/middleware-host-header": "^3.972.4",
+        "@aws-sdk/middleware-logger": "^3.972.4",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.4",
+        "@aws-sdk/middleware-user-agent": "^3.972.13",
+        "@aws-sdk/region-config-resolver": "^3.972.4",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.1",
+        "@aws-sdk/types": "^3.973.2",
+        "@aws-sdk/util-endpoints": "^3.996.1",
+        "@aws-sdk/util-user-agent-browser": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.12",
+        "@smithy/config-resolver": "^4.4.7",
+        "@smithy/core": "^3.23.4",
+        "@smithy/fetch-http-handler": "^5.3.10",
+        "@smithy/hash-node": "^4.2.9",
+        "@smithy/invalid-dependency": "^4.2.9",
+        "@smithy/middleware-content-length": "^4.2.9",
+        "@smithy/middleware-endpoint": "^4.4.18",
+        "@smithy/middleware-retry": "^4.4.35",
+        "@smithy/middleware-serde": "^4.2.10",
+        "@smithy/middleware-stack": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/node-http-handler": "^4.4.11",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/smithy-client": "^4.11.7",
+        "@smithy/types": "^4.12.1",
+        "@smithy/url-parser": "^4.2.9",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.34",
+        "@smithy/util-defaults-mode-node": "^4.2.37",
+        "@smithy/util-endpoints": "^3.2.9",
+        "@smithy/util-middleware": "^4.2.9",
+        "@smithy/util-retry": "^4.2.9",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -279,23 +230,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.0.tgz",
-      "integrity": "sha512-qy3Fmt8z4PRInM3ZqJmHihQ2tfCdj/MzbGaZpuHjYjgl1/Gcar4Pyp/zzHXh9hGEb61WNbWgsJcDUhnGIiX1TA==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.13.tgz",
+      "integrity": "sha512-eCFiLyBhJR7c/i8hZOETdzj2wsLFzi2L/w9/jajOgwmGqO8xrUExqkTZqdjROkwU62owqeqSuw4sIzlCv1E/ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/xml-builder": "^3.972.1",
-        "@smithy/core": "^3.21.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@aws-sdk/xml-builder": "^3.972.6",
+        "@smithy/core": "^3.23.4",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/signature-v4": "^5.3.9",
+        "@smithy/smithy-client": "^4.11.7",
+        "@smithy/types": "^4.12.1",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-middleware": "^4.2.9",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -303,15 +254,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.1.tgz",
-      "integrity": "sha512-/etNHqnx96phy/SjI0HRC588o4vKH5F0xfkZ13yAATV7aNrb+5gYGNE6ePWafP+FuZ3HkULSSlJFj0AxgrAqYw==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.11.tgz",
+      "integrity": "sha512-hbyoFuVm3qOAGfIPS9t7jCs8GFLFoaOs8ZmYp/chqciuHDyEGv+J365ip7YSvXSrxxUbeW9NyB1hTLt40NBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -319,20 +270,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.1.tgz",
-      "integrity": "sha512-AeopObGW5lpWbDRZ+t4EAtS7wdfSrHPLeFts7jaBzgIaCCD7TL7jAyAB9Y5bCLOPF+17+GL54djCCsjePljUAw==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.13.tgz",
+      "integrity": "sha512-a864QxQWFkdCZ5wQF0QZNKTbqAc/DFQNeARp4gOyZZdql5RHjj4CppUSfwAzS9cpw2IPY3eeJjWqLZ1QiDB/6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/fetch-http-handler": "^5.3.10",
+        "@smithy/node-http-handler": "^4.4.11",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/smithy-client": "^4.11.7",
+        "@smithy/types": "^4.12.1",
+        "@smithy/util-stream": "^4.5.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -340,24 +291,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.1.tgz",
-      "integrity": "sha512-OdbJA3v+XlNDsrYzNPRUwr8l7gw1r/nR8l4r96MDzSBDU8WEo8T6C06SvwaXR8SpzsjO3sq5KMP86wXWg7Rj4g==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.11.tgz",
+      "integrity": "sha512-kvPFn626ABLzxmjFMoqMRtmFKMeiUdWPhwxhmuPu233tqHnNuXzHv0MtrZlkzHd+rwlh9j0zCbQo89B54wIazQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/credential-provider-env": "^3.972.1",
-        "@aws-sdk/credential-provider-http": "^3.972.1",
-        "@aws-sdk/credential-provider-login": "^3.972.1",
-        "@aws-sdk/credential-provider-process": "^3.972.1",
-        "@aws-sdk/credential-provider-sso": "^3.972.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/credential-provider-env": "^3.972.11",
+        "@aws-sdk/credential-provider-http": "^3.972.13",
+        "@aws-sdk/credential-provider-login": "^3.972.11",
+        "@aws-sdk/credential-provider-process": "^3.972.11",
+        "@aws-sdk/credential-provider-sso": "^3.972.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.11",
+        "@aws-sdk/nested-clients": "^3.996.1",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/credential-provider-imds": "^4.2.9",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -365,18 +316,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.1.tgz",
-      "integrity": "sha512-CccqDGL6ZrF3/EFWZefvKW7QwwRdxlHUO8NVBKNVcNq6womrPDvqB6xc9icACtE0XB0a7PLoSTkAg8bQVkTO2w==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.11.tgz",
+      "integrity": "sha512-stdy09EpBTmsxGiXe1vB5qtXNww9wact36/uWLlSV0/vWbCOUAY2JjhPXoDVLk8n+E6r0M5HeZseLk+iTtifxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/nested-clients": "^3.996.1",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -384,22 +335,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.1.tgz",
-      "integrity": "sha512-DwXPk9GfuU/xG9tmCyXFVkCr6X3W8ZCoL5Ptb0pbltEx1/LCcg7T+PBqDlPiiinNCD6ilIoMJDWsnJ8ikzZA7Q==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.12.tgz",
+      "integrity": "sha512-gMWGnHbNSKWRj+PAiuSg0EDpEwpyIgk0v9U6EuZ1C/5/BUv25Way+E+UFB7r+YYkscuBJMJ+ai8E2K0Q8dx50g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.1",
-        "@aws-sdk/credential-provider-http": "^3.972.1",
-        "@aws-sdk/credential-provider-ini": "^3.972.1",
-        "@aws-sdk/credential-provider-process": "^3.972.1",
-        "@aws-sdk/credential-provider-sso": "^3.972.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.11",
+        "@aws-sdk/credential-provider-http": "^3.972.13",
+        "@aws-sdk/credential-provider-ini": "^3.972.11",
+        "@aws-sdk/credential-provider-process": "^3.972.11",
+        "@aws-sdk/credential-provider-sso": "^3.972.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.11",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/credential-provider-imds": "^4.2.9",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -407,16 +358,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.1.tgz",
-      "integrity": "sha512-bi47Zigu3692SJwdBvo8y1dEwE6B61stCwCFnuRWJVTfiM84B+VTSCV661CSWJmIZzmcy7J5J3kWyxL02iHj0w==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.11.tgz",
+      "integrity": "sha512-B049fvbv41vf0Fs5bCtbzHpruBDp61sPiFDxUmkAJ/zvgSAturpj2rqzV1rj2clg4mb44Uxp9rgpcODexNFlFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -424,18 +375,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.1.tgz",
-      "integrity": "sha512-dLZVNhM7wSgVUFsgVYgI5hb5Z/9PUkT46pk/SHrSmUqfx6YDvoV4YcPtaiRqviPpEGGiRtdQMEadyOKIRqulUQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.11.tgz",
+      "integrity": "sha512-vX9z8skN8vPtamVWmSCm4KQohub+1uMuRzIo4urZ2ZUMBAl1bqHatVD/roCb3qRfAyIGvZXCA/AWS03BQRMyCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.974.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/token-providers": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/nested-clients": "^3.996.1",
+        "@aws-sdk/token-providers": "3.997.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -443,17 +394,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.1.tgz",
-      "integrity": "sha512-YMDeYgi0u687Ay0dAq/pFPKuijrlKTgsaB/UATbxCs/FzZfMiG4If5ksywHmmW7MiYUF8VVv+uou3TczvLrN4w==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.11.tgz",
+      "integrity": "sha512-VR2Ju/QBdOjnWNIYuxRml63eFDLGc6Zl8aDwLi1rzgWo3rLBgtaWhWVBAijhVXzyPdQIOqdL8hvll5ybqumjeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/nested-clients": "^3.996.1",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -461,14 +412,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.1.tgz",
-      "integrity": "sha512-/R82lXLPmZ9JaUGSUdKtBp2k/5xQxvBT3zZWyKiBOhyulFotlfvdlrO8TnqstBimsl4lYEYySDL+W6ldFh6ALg==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.4.tgz",
+      "integrity": "sha512-4q2Vg7/zOB10huDBLjzzTwVjBpG22X3J3ief2XrJEgTaANZrNfA3/cGbCVNAibSbu/nIYA7tDk8WCdsIzDDc4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -476,13 +427,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.1.tgz",
-      "integrity": "sha512-JGgFl6cHg9G2FHu4lyFIzmFN8KESBiRr84gLC3Aeni0Gt1nKm+KxWLBuha/RPcXxJygGXCcMM4AykkIwxor8RA==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.4.tgz",
+      "integrity": "sha512-xFqPvTysuZAHSkdygT+ken/5rzkR7fhOoDPejAJQslZpp0XBepmCJnDOqA57ERtCTBpu8wpjTFI1ETd4S0AXEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -490,15 +441,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.1.tgz",
-      "integrity": "sha512-taGzNRe8vPHjnliqXIHp9kBgIemLE/xCaRTMH1NH0cncHeaPcjxtnCroAAM9aOlPuKvBe2CpZESyvM1+D8oI7Q==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.4.tgz",
+      "integrity": "sha512-tVbRaayUZ7y2bOb02hC3oEPTqQf2A0HpPDwdMl1qTmye/q8Mq1F1WiIoFkQwG/YQFvbyErYIDMbYzIlxzzLtjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.2",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -506,75 +457,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.0.tgz",
-      "integrity": "sha512-0bcKFXWx+NZ7tIlOo7KjQ+O2rydiHdIQahrq+fN6k9Osky29v17guy68urUKfhTobR6iY6KvxkroFWaFtTgS5w==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.13.tgz",
+      "integrity": "sha512-rGBz1n6PFxg1+5mnN1/IczesPwx0W39DZt2JPjqPiZAZ7LAqH8FS4AsawSNZqr+UFJfqtTXYpeLQnMfbMAgHhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
-        "@aws-sdk/util-arn-parser": "3.972.0",
-        "@smithy/core": "^3.20.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.972.0.tgz",
-      "integrity": "sha512-nEeUW2M9F+xdIaD98F5MBcQ4ITtykj3yKbgFZ6J0JtL3bq+Z90szQ6Yy8H/BLPYXTs3V4n9ifnBo8cprRDiE6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.972.0",
-        "@aws-sdk/xml-builder": "3.972.0",
-        "@smithy/core": "^3.20.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.0.tgz",
-      "integrity": "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.2.5",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
+        "@smithy/core": "^3.23.4",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/signature-v4": "^5.3.9",
+        "@smithy/smithy-client": "^4.11.7",
+        "@smithy/types": "^4.12.1",
+        "@smithy/util-config-provider": "^4.2.1",
+        "@smithy/util-middleware": "^4.2.9",
+        "@smithy/util-stream": "^4.5.14",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -582,17 +482,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.1.tgz",
-      "integrity": "sha512-6SVg4pY/9Oq9MLzO48xuM3lsOb8Rxg55qprEtFRpkUmuvKij31f5SQHEGxuiZ4RqIKrfjr2WMuIgXvqJ0eJsPA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.13.tgz",
+      "integrity": "sha512-p1kVYbzBxRmhuOHoL/ANJPCedqUxnVgkEjxPoxt5pQv/yzppHM7aBWciYEE9TZY59M421D3GjLfZIZBoEFboVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@smithy/core": "^3.21.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@aws-sdk/util-endpoints": "^3.996.1",
+        "@smithy/core": "^3.23.4",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -600,48 +500,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.974.0.tgz",
-      "integrity": "sha512-k3dwdo/vOiHMJc9gMnkPl1BA5aQfTrZbz+8fiDkWrPagqAioZgmo5oiaOaeX0grObfJQKDtcpPFR4iWf8cgl8Q==",
+      "version": "3.996.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.1.tgz",
+      "integrity": "sha512-XHVLFRGkuV2gh2uwBahCt65ALMb5wMpqplXEZIvFnWOCPlk60B7h7M5J9Em243K8iICDiWY6KhBEqVGfjTqlLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/middleware-host-header": "^3.972.4",
+        "@aws-sdk/middleware-logger": "^3.972.4",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.4",
+        "@aws-sdk/middleware-user-agent": "^3.972.13",
+        "@aws-sdk/region-config-resolver": "^3.972.4",
+        "@aws-sdk/types": "^3.973.2",
+        "@aws-sdk/util-endpoints": "^3.996.1",
+        "@aws-sdk/util-user-agent-browser": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.12",
+        "@smithy/config-resolver": "^4.4.7",
+        "@smithy/core": "^3.23.4",
+        "@smithy/fetch-http-handler": "^5.3.10",
+        "@smithy/hash-node": "^4.2.9",
+        "@smithy/invalid-dependency": "^4.2.9",
+        "@smithy/middleware-content-length": "^4.2.9",
+        "@smithy/middleware-endpoint": "^4.4.18",
+        "@smithy/middleware-retry": "^4.4.35",
+        "@smithy/middleware-serde": "^4.2.10",
+        "@smithy/middleware-stack": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/node-http-handler": "^4.4.11",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/smithy-client": "^4.11.7",
+        "@smithy/types": "^4.12.1",
+        "@smithy/url-parser": "^4.2.9",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.34",
+        "@smithy/util-defaults-mode-node": "^4.2.37",
+        "@smithy/util-endpoints": "^3.2.9",
+        "@smithy/util-middleware": "^4.2.9",
+        "@smithy/util-retry": "^4.2.9",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -649,15 +549,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.1.tgz",
-      "integrity": "sha512-voIY8RORpxLAEgEkYaTFnkaIuRwVBEc+RjVZYcSSllPV+ZEKAacai6kNhJeE3D70Le+JCfvRb52tng/AVHY+jQ==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.4.tgz",
+      "integrity": "sha512-3GrJYv5eI65oCKveBZP7Q246dVP+tqeys9aKMB0dfX1glUWfppWlxIu52derqdNb9BX9lxYmeiaBcBIqOAYSgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.7",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -665,29 +565,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.972.0.tgz",
-      "integrity": "sha512-2udiRijmjpN81Pvajje4TsjbXDZNP6K9bYUanBYH8hXa/tZG5qfGCySD+TyX0sgDxCQmEDMg3LaQdfjNHBDEgQ==",
+      "version": "3.996.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.1.tgz",
+      "integrity": "sha512-Mj4npuEtVHFjGZHTBwhBvBzmgKHY7UsfroZWWzjpVP5YJaMTPeihsotuQLba5uQthEZyaeWs6dTu3Shr0qKFFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/protocol-http": "^5.3.9",
+        "@smithy/signature-v4": "^5.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -695,17 +582,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.974.0.tgz",
-      "integrity": "sha512-cBykL0LiccKIgNhGWvQRTPvsBLPZxnmJU3pYxG538jpFX8lQtrCy1L7mmIHNEdxIdIGEPgAEHF8/JQxgBToqUQ==",
+      "version": "3.997.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.997.0.tgz",
+      "integrity": "sha512-UdG36F7lU9aTqGFRieEyuRUJlgEJBqKeKKekC0esH21DbUSKhPR1kZBah214kYasIaWe1hLJLaqUigoTa5hZAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.13",
+        "@aws-sdk/nested-clients": "^3.996.1",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/property-provider": "^4.2.9",
+        "@smithy/shared-ini-file-loader": "^4.4.4",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -713,12 +600,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.0.tgz",
-      "integrity": "sha512-jYIdB7a7jhRTvyb378nsjyvJh1Si+zVduJ6urMNGpz8RjkmHZ+9vM2H07XaIB2Cfq0GhJRZYOfUCH8uqQhqBkQ==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.2.tgz",
+      "integrity": "sha512-maTZwGsALtnAw4TJr/S6yERAosTwPduu0XhUV+SdbvRZtCOgSgk1ttL2R0XYzvkYSpvbtJocn77tBXq2AKglBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -726,9 +613,9 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.0.tgz",
-      "integrity": "sha512-RM5Mmo/KJ593iMSrALlHEOcc9YOIyOsDmS5x2NLOMdEmzv1o00fcpAkCQ02IGu1eFneBFT7uX0Mpag0HI+Cz2g==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
+      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -738,28 +625,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.972.0.tgz",
-      "integrity": "sha512-6JHsl1V/a1ZW8D8AFfd4R52fwZPnZ5H4U6DS8m/bWT8qad72NvbOFAC7U2cDtFs2TShqUO3TEiX/EJibtY3ijg==",
+      "version": "3.996.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.1.tgz",
+      "integrity": "sha512-7cJyd+M5i0IoqWkJa1KFx8KNCGIx+Ywu+lT53KpqX7ReVwz03DCKUqvZ/y65vdKwo9w9/HptSAeLDluO5MpGIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/types": "^4.12.1",
+        "@smithy/url-parser": "^4.2.9",
+        "@smithy/util-endpoints": "^3.2.9",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -767,9 +641,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.3.tgz",
-      "integrity": "sha512-FNUqAjlKAGA7GM05kywE99q8wiPHPZqrzhq3wXRga6PRD6A0kzT85Pb0AzYBVTBRpSrKyyr6M92Y6bnSBVp2BA==",
+      "version": "3.965.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
+      "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -779,27 +653,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.1.tgz",
-      "integrity": "sha512-IgF55NFmJX8d9Wql9M0nEpk2eYbuD8G4781FN4/fFgwTXBn86DvlZJuRWDCMcMqZymnBVX7HW9r+3r9ylqfW0w==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.4.tgz",
+      "integrity": "sha512-GHb+8XHv6hfLWKQKAKaSOm+vRvogg07s+FWtbR3+eCXXPSFn9XVmiYF4oypAxH7dGIvoxkVG/buHEnzYukyJiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/types": "^4.12.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.1.tgz",
-      "integrity": "sha512-oIs4JFcADzoZ0c915R83XvK2HltWupxNsXUIuZse2rgk7b97zTpkxaqXiH0h9ylh31qtgo/t8hp4tIqcsMrEbQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.12.tgz",
+      "integrity": "sha512-c1n3wBK6te+Vd9qU86nF8AsYuiBsxLn0AADGWyFX7vEADr3btaAg5iPQT6GYj6rvzSOEVVisvaAatOWInlJUbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.13",
+        "@aws-sdk/types": "^3.973.2",
+        "@smithy/node-config-provider": "^4.3.9",
+        "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -815,13 +689,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.1.tgz",
-      "integrity": "sha512-6zZGlPOqn7Xb+25MAXGb1JhgvaC5HjZj6GzszuVrnEgbhvzBRFGKYemuHBV4bho+dtqeYKPgaZUv7/e80hIGNg==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.6.tgz",
+      "integrity": "sha512-YrXu+UnfC8IdARa4ZkrpcyuRmA/TVgYW6Lcdtvi34NQgRjM1hTirNirN+rGb+s/kNomby8oJiIAu0KNbiZC7PA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.12.1",
+        "fast-xml-parser": "5.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2410,12 +2284,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.10.tgz",
+      "integrity": "sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2423,16 +2297,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.9.tgz",
+      "integrity": "sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.1",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2440,20 +2314,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.21.0.tgz",
-      "integrity": "sha512-bg2TfzgsERyETAxc/Ims/eJX8eAnIeTi4r4LHpMpfF/2NyO6RsWis0rjKcCPaGksljmOb23BZRiCeT/3NvwkXw==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.6.tgz",
+      "integrity": "sha512-4xE+0L2NrsFKpEVFlFELkIHQddBvMbQ41LRIP74dGCXnY1zQ9DgksrBcRBDJT+iOzGy4VEJIeU3hkUK5mn06kg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-stream": "^4.5.15",
+        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/uuid": "^1.1.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2461,15 +2335,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.10.tgz",
+      "integrity": "sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2477,15 +2351,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.11.tgz",
+      "integrity": "sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2493,14 +2367,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.10.tgz",
+      "integrity": "sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2508,12 +2382,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.10.tgz",
+      "integrity": "sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2521,9 +2395,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
+      "integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2533,13 +2407,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.10.tgz",
+      "integrity": "sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2547,18 +2421,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.10.tgz",
-      "integrity": "sha512-kwWpNltpxrvPabnjEFvwSmA+66l6s2ReCvgVSzW/z92LU4T28fTdgZ18IdYRYOrisu2NMQ0jUndRScbO65A/zg==",
+      "version": "4.4.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.20.tgz",
+      "integrity": "sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.21.0",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/core": "^3.23.6",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-middleware": "^4.2.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2566,19 +2440,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.26",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.26.tgz",
-      "integrity": "sha512-ozZMoTAr+B2aVYfLYfkssFvc8ZV3p/vLpVQ7/k277xxUOA9ykSPe5obL2j6yHfbdrM/SZV7qj0uk/hSqavHrLw==",
+      "version": "4.4.37",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.37.tgz",
+      "integrity": "sha512-/1psZZllBBSQ7+qo5+hhLz7AEPGLx3Z0+e3ramMBEuPK2PfvLK4SrncDB9VegX5mBn+oP/UTDrM6IHrFjvX1ZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/service-error-classification": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/uuid": "^1.1.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2586,13 +2460,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.11.tgz",
+      "integrity": "sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2600,12 +2474,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.10.tgz",
+      "integrity": "sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2613,14 +2487,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.10.tgz",
+      "integrity": "sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2628,15 +2502,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.8.tgz",
-      "integrity": "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.12.tgz",
+      "integrity": "sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/abort-controller": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2644,12 +2518,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.10.tgz",
+      "integrity": "sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2657,12 +2531,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.10.tgz",
+      "integrity": "sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2670,13 +2544,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.10.tgz",
+      "integrity": "sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2684,12 +2558,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.10.tgz",
+      "integrity": "sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2697,24 +2571,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.10.tgz",
+      "integrity": "sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0"
+        "@smithy/types": "^4.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.5.tgz",
+      "integrity": "sha512-pHgASxl50rrtOztgQCPmOXFjRW+mCd7ALr/3uXNzRrRoGV5G2+78GOsQ3HlQuBVHCh9o6xqMNvlIKZjWn4Euug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2722,18 +2596,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.10.tgz",
+      "integrity": "sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.1",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-uri-escape": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2741,17 +2615,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.11",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.11.tgz",
-      "integrity": "sha512-6o804SCyHGMXAb5mFJ+iTy9kVKv7F91a9szN0J+9X6p8A0NrdpUxdaC57aye2ipQkP2C4IAqETEpGZ0Zj77Haw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.0.tgz",
+      "integrity": "sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.21.0",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@smithy/core": "^3.23.6",
+        "@smithy/middleware-endpoint": "^4.4.20",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.15",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2759,9 +2633,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2771,13 +2645,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.10.tgz",
+      "integrity": "sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/querystring-parser": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2785,13 +2659,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
+      "integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2799,9 +2673,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
+      "integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2811,9 +2685,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
+      "integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2823,12 +2697,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
+      "integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2836,9 +2710,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
+      "integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2848,14 +2722,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.25",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.25.tgz",
-      "integrity": "sha512-8ugoNMtss2dJHsXnqsibGPqoaafvWJPACmYKxJ4E6QWaDrixsAemmiMMAVbvwYadjR0H9G2+AlzsInSzRi8PSw==",
+      "version": "4.3.36",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.36.tgz",
+      "integrity": "sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2863,17 +2737,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.28",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.28.tgz",
-      "integrity": "sha512-mjUdcP8h3E0K/XvNMi9oBXRV3DMCzeRiYIieZ1LQ7jq5tu6GH/GTWym7a1xIIE0pKSoLcpGsaImuQhGPSIJzAA==",
+      "version": "4.2.39",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.39.tgz",
+      "integrity": "sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2881,13 +2755,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.1.tgz",
+      "integrity": "sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2895,9 +2769,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
+      "integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2907,12 +2781,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.10.tgz",
+      "integrity": "sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2920,13 +2794,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.10.tgz",
+      "integrity": "sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/service-error-classification": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2934,18 +2808,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.10.tgz",
-      "integrity": "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==",
+      "version": "4.5.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.15.tgz",
+      "integrity": "sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.11",
+        "@smithy/node-http-handler": "^4.4.12",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2953,9 +2827,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
+      "integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2965,12 +2839,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
+      "integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2978,9 +2852,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
+      "integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3297,24 +3171,37 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3599,9 +3486,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3693,9 +3580,9 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -3956,9 +3843,9 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.31.8",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.8.tgz",
-      "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
+      "version": "0.31.9",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.9.tgz",
+      "integrity": "sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4950,9 +4837,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -4961,7 +4848,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5300,9 +5187,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5908,9 +5795,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6924,24 +6811,37 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7284,7 +7184,7 @@
         "cli-table3": "^0.6.3",
         "commander": "^14.0.2",
         "drizzle-orm": "^0.45.1",
-        "hono": "^4.11.7",
+        "hono": "^4.0.0",
         "jsonwebtoken": "^9.0.0",
         "nanoid": "^5.0.0",
         "nodemailer": "^7.0.12",


### PR DESCRIPTION
## Summary
- Patches 3 critical/high CVEs in fast-xml-parser (transitive via @aws-sdk/xml-builder)
- CVEs: GHSA-37qj-frw5-hhjh, GHSA-jmr7-xgp7-cmfj, GHSA-m7jm-9gc2-mpf2
- Production-only audit now passes at high severity level

## Test plan
- [x] `npm audit --omit=dev --audit-level=high` passes (0 vulnerabilities)
- [x] `npm test` passes (808/808 tests, 35 test files)
- [ ] CI Security workflow passes

@codex please review this PR for code quality, security, and best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)